### PR TITLE
Allow an address as key in GetStorage

### DIFF
--- a/blockchain.js
+++ b/blockchain.js
@@ -49,8 +49,17 @@ module.exports = {
         })
     },
 
+    getScriptHash: (input) => {
+        const hash = neon.wallet.getScriptHashFromAddress(input)
+        return util.reverseHex(hash)
+    },
+
     getStorage: (key) => {
-        key = util.str2hex(key)
+        if (neon.wallet.isAddress(key)) {
+            key = module.exports.getScriptHash(key)
+        } else {
+            key = util.str2hex(key)
+        }
         return module.exports.queryRPC(
             'getstorage',
             [config.scriptHash, key]

--- a/index.js
+++ b/index.js
@@ -1,11 +1,26 @@
-const Neon = require('@cityofzion/neon-js').default
 const node = require('./blockchain')
 const config = require('./config')
 const account = Neon.create.account(config.wif)
 
-// node.getStorage('AGs7dP8tX1KgjXopLELdmZed85GnEkFPRh').then((res) => {
-node.getStorage('TomciuIsGekk').then((res) => {
-    if (typeof res === "string") {
-        console.log(res);
+// Invoke a smart contract with a method and an array of strings
+node.invokeContract('WriteToStorage', ['someStorageKey', 'Hello World!'], account, (res) => {
+    if (res.result === true) {
+        // Transaction successful. The stored data can be retrieved on the next block.
+        console.log('Transaction processed!')
+    } else {
+        console.log('Transaction has not been processed.')
     }
+})
+
+// Get a storage key
+node.getStorage('someStorageKey').then((res) => {
+    if (typeof res === "string") {
+        //Do something with the resulting value
+    }
+})
+
+// Test a transaction. This returns expected values from your smart contract, and doesn't send a transaction. Costs 0 gas.
+// Note: These are not signed transactions, so it doesn't return data that uses a sender's address.
+node.testContract('WriteToStorage', ['someStorageKey', 'Hello World!'], (res) => {
+    console.dir(res)
 })

--- a/index.js
+++ b/index.js
@@ -1,26 +1,11 @@
+const Neon = require('@cityofzion/neon-js').default
 const node = require('./blockchain')
 const config = require('./config')
 const account = Neon.create.account(config.wif)
 
-// Invoke a smart contract with a method and an array of strings
-node.invokeContract('WriteToStorage', ['someStorageKey', 'Hello World!'], account, (res) => {
-    if (res.result === true) {
-        // Transaction successful. The stored data can be retrieved on the next block.
-        console.log('Transaction processed!')
-    } else {
-        console.log('Transaction has not been processed.')
-    }
-})
-
-// Get a storage key
-node.getStorage('someStorageKey').then((res) => {
+// node.getStorage('AGs7dP8tX1KgjXopLELdmZed85GnEkFPRh').then((res) => {
+node.getStorage('TomciuIsGekk').then((res) => {
     if (typeof res === "string") {
-        //Do something with the resulting value
+        console.log(res);
     }
-})
-
-// Test a transaction. This returns expected values from your smart contract, and doesn't send a transaction. Costs 0 gas.
-// Note: These are not signed transactions, so it doesn't return data that uses a sender's address.
-node.testContract('WriteToStorage', ['someStorageKey', 'Hello World!'], (res) => {
-    console.dir(res)
 })


### PR DESCRIPTION
When using GetStorage and the key is a public NEO address, then the encoding should be done with getScriptHashFromAddress() instead of str2hex()